### PR TITLE
Link Hydra audio to Strudel output

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,19 +4,25 @@ import StrudelRepl from './components/StrudelRepl';
 import HydraRepl from './components/HydraRepl';
 import { Monitor } from 'lucide-react';
 import { initStrudel } from '@strudel/web';
+import { initHydraBridge, type HydraBridge } from './utils/strudelHydraBridge';
 
 function App() {
   const [showHydraWindow, setShowHydraWindow] = useState(false);
   const [engineInitialized, setEngineInitialized] = useState(false);
   const [isInitializing, setIsInitializing] = useState(false);
-  const [audioData, setAudioData] = useState<Uint8Array | undefined>(undefined);
-  const [visualMode, setVisualMode] = useState<'default' | 'bass'>('default');
-  const analyserRef = useRef<AnalyserNode | null>(null);
-  const animationRef = useRef<number | null>(null);
+  const [hydraLinked, setHydraLinked] = useState(false);
+  const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
+  const [hydraStatus, setHydraStatus] = useState('Hydra audio source: none');
+  const [hydraHudValue, setHydraHudValue] = useState(0);
+  const [hydraReady, setHydraReady] = useState(false);
   const hydraInstanceRef = useRef<any>(null);
+  const strudelReplRef = useRef<any>(null);
+  const hydraBridgeRef = useRef<HydraBridge | null>(null);
+  const hudAnimationRef = useRef<number | null>(null);
 
-  const handleHydraInit = useCallback((synth: any) => {
-    hydraInstanceRef.current = synth;
+  const handleHydraInit = useCallback((hydra: any) => {
+    hydraInstanceRef.current = hydra;
+    setHydraReady(true);
   }, []);
 
   const handleHydraExecute = useCallback((code: string) => {
@@ -47,44 +53,13 @@ function App() {
         prebake: () => (window as any).samples('github:tidalcycles/dirt-samples')
       });
 
-      // Make REPL globally accessible
       (window as any).repl = repl;
+      strudelReplRef.current = repl;
 
-      // Extract or create a shared AudioContext for Hydra
       const sharedAudioContext = (repl as any).audioContext || (repl as any).context || new (window as any).AudioContext();
+      await sharedAudioContext.resume();
+      setAudioContext(sharedAudioContext);
       (window as any).replAudio = sharedAudioContext;
-
-      // Set up analyser node for audio data extraction
-      const analyser = sharedAudioContext.createAnalyser();
-      analyser.fftSize = 256; // reasonable resolution for visual sync
-      analyserRef.current = analyser;
-
-      // Connect analyser properly - it should be in the audio chain
-      // We'll connect it to the destination so it can analyze the output
-      analyser.connect(sharedAudioContext.destination);
-
-      // Try to find and connect Strudel's output to our analyser
-      // This allows us to analyze the audio without breaking the chain
-      if ((repl as any).output) {
-        try {
-          (repl as any).output.connect(analyser);
-          console.log('Connected Strudel output to analyser');
-        } catch (e) {
-          console.warn('Could not connect Strudel output to analyser:', e);
-        }
-      }
-
-      // Start animation loop to pull frequency data
-      const updateAudioData = () => {
-        if (analyserRef.current) {
-          const bufferLength = analyserRef.current.frequencyBinCount;
-          const dataArray = new Uint8Array(bufferLength);
-          analyserRef.current.getByteFrequencyData(dataArray);
-          setAudioData(dataArray);
-        }
-        animationRef.current = requestAnimationFrame(updateAudioData);
-      };
-      updateAudioData();
 
       setEngineInitialized(true);
       console.log('Strudel engine initialized successfully', repl, { sharedAudioContext });
@@ -104,37 +79,95 @@ function App() {
     alert("Pop-out functionality coming in next phase!");
   };
 
-  // Cleanup on unmount
   useEffect(() => {
+    if (!engineInitialized || !hydraReady || hydraLinked) return;
+    if (!hydraInstanceRef.current || !strudelReplRef.current) return;
+
+    const ctx = (strudelReplRef.current as any).audioContext || (strudelReplRef.current as any).context || audioContext;
+    if (!ctx || !(strudelReplRef.current as any).output) return;
+
+    const bridge = initHydraBridge({
+      hydra: hydraInstanceRef.current,
+      strudel: strudelReplRef.current,
+      audioContext: ctx,
+    });
+
+    if (bridge) {
+      hydraBridgeRef.current = bridge;
+      setHydraLinked(true);
+      setHydraStatus('Hydra audio source: Strudel (a.fft)');
+    }
+
     return () => {
-      if (animationRef.current) cancelAnimationFrame(animationRef.current);
-      if (analyserRef.current) analyserRef.current.disconnect();
+      hydraBridgeRef.current?.analyser.disconnect();
+      hydraBridgeRef.current = null;
+      setHydraLinked(false);
+      setHydraStatus('Hydra audio source: none');
+    };
+  }, [engineInitialized, audioContext, hydraReady]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+
+    const updateHud = () => {
+      const val = (window as any).a?.fft?.[0] ?? 0;
+      setHydraHudValue(val);
+      hudAnimationRef.current = requestAnimationFrame(updateHud);
+    };
+
+    updateHud();
+
+    return () => {
+      if (hudAnimationRef.current) cancelAnimationFrame(hudAnimationRef.current);
     };
   }, []);
+
+  const playTestPattern = () => {
+    const repl = (window as any).repl;
+    if (!repl || !repl.evaluate) return;
+    repl.evaluate('s("bd*4").gain(0.8)');
+  };
+
+  const hushAudio = () => {
+    const repl = (window as any).repl;
+    if (repl && repl.stop) repl.stop();
+  };
 
   return (
     <div className="w-screen h-screen bg-pm-bg text-pm-text overflow-hidden flex flex-col font-mono">
       {/* Header / Status Bar */}
-      <header className="h-8 bg-pm-panel border-b border-pm-border flex items-center justify-between px-4 select-none">
-        <div className="flex items-center gap-4">
-          <span className="text-pm-secondary font-bold tracking-widest">BASILISK</span>
-          <span className="text-xs text-gray-500">v0.1.0-alpha</span>
+      <header className="bg-pm-panel border-b border-pm-border flex flex-col">
+        <div className="h-10 flex items-center justify-between px-4 select-none">
+          <div className="flex items-center gap-4">
+            <span className="text-pm-secondary font-bold tracking-widest">BASILISK</span>
+            <span className="text-xs text-gray-500">v0.1.0-alpha</span>
+          </div>
+          <div className="flex items-center gap-4 text-xs">
+            <span className={engineInitialized ? 'text-green-400' : 'text-red-400'}>
+              Audio: {engineInitialized ? 'running' : 'stopped'}
+            </span>
+            <span className={hydraLinked ? 'text-green-400' : 'text-yellow-400'}>
+              {hydraStatus}
+            </span>
+          </div>
         </div>
-        <div className="flex items-center gap-4 text-xs">
-          <button
-            onClick={startEngine}
-            disabled={isInitializing || engineInitialized}
-            className={`px-3 py-1 font-mono tracking-wider transition-colors border border-pm-border ${engineInitialized
-              ? 'bg-green-500/20 text-green-500 cursor-default'
-              : isInitializing
-                ? 'bg-yellow-500/20 text-yellow-500 cursor-wait'
-                : 'bg-pm-border hover:bg-pm-accent hover:text-black cursor-pointer'
-              }`}
-          >
-            {engineInitialized ? 'ENGINE: READY' : isInitializing ? 'STARTING...' : 'START_ENGINE'}
-          </button>
-          <span className="text-green-500">SYSTEM: ONLINE</span>
-          <span>MEM: 64K</span>
+        <div className="flex items-center justify-between px-4 pb-2 text-xs gap-4">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={startEngine}
+              disabled={isInitializing || engineInitialized}
+              className={`px-3 py-2 font-mono tracking-wider transition-colors border border-pm-border rounded ${engineInitialized
+                ? 'bg-green-500/20 text-green-500 cursor-default'
+                : isInitializing
+                  ? 'bg-yellow-500/20 text-yellow-500 cursor-wait'
+                  : 'bg-pm-border hover:bg-pm-accent hover:text-black cursor-pointer'
+                }`}
+            >
+              {engineInitialized ? 'Audio running' : isInitializing ? 'Starting…' : 'Start audio engine'}
+            </button>
+            <div className="text-pm-secondary">Shared AudioContext → Strudel + Hydra</div>
+          </div>
+          <div className="text-pm-secondary">Hydra link status: {hydraLinked ? 'linked' : 'not linked'}</div>
         </div>
       </header>
 
@@ -143,13 +176,21 @@ function App() {
 
         {/* Left Pane: Code (Strudel) */}
         <div className="w-1/2 h-full border-r border-pm-border flex flex-col">
-          <StrudelRepl className="flex-1" engineReady={engineInitialized} />
+          <StrudelRepl
+            className="flex-1"
+            engineReady={engineInitialized}
+            onTestPattern={playTestPattern}
+            onHalt={hushAudio}
+            statusLabel={engineInitialized && hydraLinked ? 'Output: speakers + Hydra' : 'Output: waiting for engine'}
+          />
 
           {/* Hydra Editor */}
           <div className="h-1/2 border-t border-pm-border flex flex-col">
             <HydraRepl
               className="flex-1"
               onExecute={handleHydraExecute}
+              onLoadPreset={handleHydraExecute}
+              linkStatus={hydraStatus}
             />
           </div>
         </div>
@@ -166,34 +207,32 @@ function App() {
             </button>
           </div>
 
-          {/* Visual mode selector */}
-          <div className="absolute top-4 left-4 z-10 flex gap-2">
-            <select
-              value={visualMode}
-              onChange={(e) => setVisualMode(e.target.value as 'default' | 'bass')}
-              className="bg-pm-panel text-pm-text border border-pm-border rounded px-2 py-1"
-            >
-              <option value="default">Default</option>
-              <option value="bass">Bass‑Responsive</option>
-            </select>
-          </div>
-
           <HydraCanvas
             className="w-full h-full"
-            audioContext={(window as any).replAudio}
-            audioData={audioData}
-            visualMode={visualMode}
+            audioContext={audioContext ?? (window as any).replAudio}
             onInit={handleHydraInit}
           />
 
-          {/* Overlay UI elements could go here */}
           <div className="absolute bottom-4 left-4 pointer-events-none">
-            <div className="text-xs text-pm-secondary opacity-50">
-              FPS: 60.0
-              <br />
-              RES: 1920x1080
+            <div className="text-xs text-pm-secondary opacity-70">
+              {hydraStatus}
             </div>
           </div>
+
+          {import.meta.env.DEV && (
+            <div className="absolute bottom-4 right-4 z-50 rounded bg-black/70 px-2 py-1 text-xs text-white pointer-events-none w-48">
+              <div className="flex items-center justify-between">
+                <span className="opacity-70">a.fft[0]</span>
+                <span>{hydraHudValue.toFixed(3)}</span>
+              </div>
+              <div className="mt-1 h-1.5 w-full bg-neutral-700 overflow-hidden rounded">
+                <div
+                  className="h-full bg-green-400"
+                  style={{ width: `${Math.min(100, Math.max(0, hydraHudValue * 100))}%` }}
+                />
+              </div>
+            </div>
+          )}
         </div>
 
       </div>

--- a/src/components/HydraCanvas.tsx
+++ b/src/components/HydraCanvas.tsx
@@ -4,21 +4,13 @@ import Hydra from 'hydra-synth';
 type Props = {
     className?: string;
     /**
+     * Callback when Hydra is initialized.
+     */
+    onInit?: (hydra: any) => void;
+    /**
      * Optional shared AudioContext from Strudel. If not provided, Hydra will create its own.
      */
     audioContext?: AudioContext;
-    /**
-     * Optional Uint8Array of frequency data from an AnalyserNode.
-     */
-    audioData?: Uint8Array;
-    /**
-     * Visual mode selector – can be used to switch shader behaviours.
-     */
-    visualMode?: 'default' | 'bass';
-    /**
-     * Callback when Hydra is initialized.
-     */
-    onInit?: (synth: any) => void;
 };
 
 export default function HydraCanvas(props: Props) {
@@ -49,9 +41,9 @@ export default function HydraCanvas(props: Props) {
 
         // Initialise Hydra
         const hydra = new Hydra({
-            canvas: canvas,
+            canvas,
             audioContext,
-            detectAudio: true,
+            detectAudio: false,
             makeGlobal: true,
             enableStreamCapture: false,
             width: canvas.width,
@@ -61,7 +53,7 @@ export default function HydraCanvas(props: Props) {
         hydraInstance.current = hydra;
 
         if (props.onInit) {
-            props.onInit(hydra.synth);
+            props.onInit(hydra);
         }
 
         // Expose Hydra globals for debugging

--- a/src/components/HydraRepl.tsx
+++ b/src/components/HydraRepl.tsx
@@ -7,6 +7,8 @@ type Props = {
     className?: string;
     onExecute: (code: string) => void;
     initialCode?: string;
+    onLoadPreset?: (code: string) => void;
+    linkStatus?: string;
 };
 
 const DEFAULT_CODE = `// Hydra Visuals
@@ -28,8 +30,27 @@ shape(99, .15, .5)
   .scale(1.6, .6, 1)
   .out()`;
 
-export default function HydraRepl({ className, onExecute, initialCode = DEFAULT_CODE }: Props) {
+const AUDIO_TEST = `a.setBins(4)
+
+osc(10, 0, () => a.fft[0] * 4)
+  .rotate(0, () => a.fft[1] * 0.3)
+  .modulateScale(noise(3, 0.1), () => a.fft[2] * 0.2)
+  .out()`;
+
+const SIMPLE_FEEDBACK = `osc(5, 0.1, 0.8)
+  .rotate(0.1, 0.05)
+  .modulate(noise(2, 0.2), 0.2)
+  .out()`;
+
+const presetMap: Record<string, string> = {
+    none: DEFAULT_CODE,
+    audio: AUDIO_TEST,
+    feedback: SIMPLE_FEEDBACK,
+};
+
+export default function HydraRepl({ className, onExecute, initialCode = DEFAULT_CODE, onLoadPreset, linkStatus }: Props) {
     const [code, setCode] = useState(initialCode);
+    const [preset, setPreset] = useState<'none' | 'audio' | 'feedback'>('none');
 
     const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
         if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
@@ -38,6 +59,13 @@ export default function HydraRepl({ className, onExecute, initialCode = DEFAULT_
         }
     }, [code, onExecute]);
 
+    const loadPreset = (value: 'none' | 'audio' | 'feedback') => {
+        setPreset(value);
+        const presetCode = presetMap[value];
+        setCode(presetCode);
+        (onLoadPreset ?? onExecute)(presetCode);
+    };
+
     return (
         <div className={`flex flex-col bg-pm-panel ${className}`}>
             <div className="flex justify-between items-center p-2 border-b border-pm-border select-none bg-pm-panel">
@@ -45,13 +73,37 @@ export default function HydraRepl({ className, onExecute, initialCode = DEFAULT_
                     <div className="w-3 h-3 rounded-full bg-blue-500/50"></div>
                     <span className="text-pm-secondary font-mono text-sm tracking-wider">HYDRA_VISUALS</span>
                 </div>
+                <div className="flex items-center gap-2 text-xs font-mono">
+                    <span className="text-pm-secondary">{linkStatus ?? 'Hydra audio source: unknown'}</span>
+                    <button
+                        onClick={() => onExecute(code)}
+                        className="flex items-center gap-1 px-2 py-1 text-xs bg-pm-border hover:bg-pm-accent hover:text-black transition-colors rounded"
+                        title="Run Code (Ctrl+Enter)"
+                    >
+                        <Play size={10} />
+                        RUN
+                    </button>
+                </div>
+            </div>
+            <div className="flex items-center gap-2 px-2 py-2 text-xs border-b border-pm-border bg-black/30">
+                <span className="text-pm-secondary">Presets:</span>
                 <button
-                    onClick={() => onExecute(code)}
-                    className="flex items-center gap-1 px-2 py-1 text-xs bg-pm-border hover:bg-pm-accent hover:text-black transition-colors rounded"
-                    title="Run Code (Ctrl+Enter)"
+                    className={`px-2 py-1 rounded border ${preset === 'audio' ? 'bg-pm-accent text-black border-pm-accent' : 'border-pm-border'}`}
+                    onClick={() => loadPreset('audio')}
                 >
-                    <Play size={10} />
-                    RUN
+                    Hydra audio test (a.fft)
+                </button>
+                <button
+                    className={`px-2 py-1 rounded border ${preset === 'feedback' ? 'bg-pm-accent text-black border-pm-accent' : 'border-pm-border'}`}
+                    onClick={() => loadPreset('feedback')}
+                >
+                    Simple feedback
+                </button>
+                <button
+                    className={`px-2 py-1 rounded border ${preset === 'none' ? 'bg-pm-accent text-black border-pm-accent' : 'border-pm-border'}`}
+                    onClick={() => loadPreset('none')}
+                >
+                    Reset
                 </button>
             </div>
             <div className="flex-1 overflow-hidden relative" onKeyDown={handleKeyDown}>

--- a/src/components/StrudelRepl.tsx
+++ b/src/components/StrudelRepl.tsx
@@ -9,7 +9,15 @@ Object.assign(window, Strudel, { samples });
 
 const defaultCode = `s("bd sd")`;
 
-export default function StrudelRepl({ className, engineReady }: { className?: string; engineReady: boolean }) {
+type Props = {
+    className?: string;
+    engineReady: boolean;
+    onTestPattern?: () => void;
+    onHalt?: () => void;
+    statusLabel?: string;
+};
+
+export default function StrudelRepl({ className, engineReady, onTestPattern, onHalt, statusLabel }: Props) {
     const [code, setCode] = useState(defaultCode);
 
     const runCode = async () => {
@@ -41,6 +49,10 @@ export default function StrudelRepl({ className, engineReady }: { className?: st
     };
 
     const stopCode = () => {
+        if (onHalt) {
+            onHalt();
+            return;
+        }
         const repl = (window as any).repl;
         if (repl && repl.stop) {
             repl.stop();
@@ -54,7 +66,10 @@ export default function StrudelRepl({ className, engineReady }: { className?: st
                     <div className="w-3 h-3 rounded-full bg-red-500/50"></div>
                     <span className="text-pm-accent font-mono text-sm tracking-wider">STRUDEL_CORE</span>
                 </div>
-                <div className="space-x-2 font-mono text-xs">
+                <div className="flex items-center gap-2 font-mono text-xs">
+                    <span className={`px-2 py-1 rounded ${engineReady ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-300'}`}>
+                        {statusLabel ?? (engineReady ? 'Engine: ready' : 'Engine: stopped')}
+                    </span>
                     <button
                         onClick={runCode}
                         disabled={!engineReady}
@@ -71,6 +86,16 @@ export default function StrudelRepl({ className, engineReady }: { className?: st
                         className="px-3 py-1 bg-pm-border hover:bg-red-500 hover:text-black transition-colors border border-pm-border"
                     >
                         HALT
+                    </button>
+                    <button
+                        onClick={onTestPattern}
+                        disabled={!engineReady}
+                        className={`px-3 py-1 transition-colors border border-pm-border ${engineReady
+                            ? 'bg-pm-border hover:bg-pm-accent hover:text-black cursor-pointer'
+                            : 'bg-pm-border/50 text-gray-600 cursor-not-allowed'
+                            }`}
+                    >
+                        Debug: Play test pattern
                     </button>
                 </div>
             </div>

--- a/src/utils/strudelHydraBridge.ts
+++ b/src/utils/strudelHydraBridge.ts
@@ -1,0 +1,77 @@
+export type HydraLike = {
+    synth: any;
+    detectAudio: boolean;
+};
+
+export type StrudelReplLike = {
+    output?: AudioNode;
+    audioContext?: AudioContext;
+    context?: AudioContext;
+};
+
+export type HydraBridge = {
+    analyser: AnalyserNode;
+    fft: number[];
+    bins: number;
+    tick: () => void;
+    setBins: (bins: number) => void;
+};
+
+/**
+ * Minimal bridge that feeds Hydra's `a.fft` values from Strudel's audio output.
+ * This avoids Hydra's microphone-based audio detection while keeping a single audio graph.
+ */
+export function initHydraBridge({
+    hydra,
+    strudel,
+    audioContext,
+}: {
+    hydra: HydraLike;
+    strudel: StrudelReplLike;
+    audioContext: AudioContext;
+}): HydraBridge | null {
+    if (!hydra || !strudel?.output || !audioContext) return null;
+
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 1024;
+    analyser.smoothingTimeConstant = 0.8;
+
+    try {
+        strudel.output.connect(analyser);
+    } catch (err) {
+        console.warn('Unable to connect Strudel output to Hydra analyser', err);
+        return null;
+    }
+
+    const dataArray = new Uint8Array(analyser.frequencyBinCount);
+
+    const hydraAudio: HydraBridge = {
+        analyser,
+        bins: 4,
+        fft: Array(4).fill(0),
+        setBins: (bins: number) => {
+            hydraAudio.bins = Math.max(1, bins);
+            hydraAudio.fft = Array(hydraAudio.bins).fill(0);
+        },
+        tick: () => {
+            analyser.getByteFrequencyData(dataArray);
+            const chunk = dataArray.length / hydraAudio.bins;
+            hydraAudio.fft = hydraAudio.fft.map((_, idx) => {
+                const start = Math.floor(idx * chunk);
+                const end = Math.floor((idx + 1) * chunk);
+                const slice = dataArray.slice(start, end);
+                const sum = slice.reduce((acc, val) => acc + val, 0);
+                const avg = slice.length ? sum / slice.length : 0;
+                return avg / 255; // normalize 0-1
+            });
+        },
+    };
+
+    // Wire into Hydra's audio slot and tick loop
+    hydra.synth.a = hydraAudio;
+    hydra.detectAudio = true;
+
+    // expose for debugging
+    (window as any).a = hydraAudio;
+    return hydraAudio;
+}


### PR DESCRIPTION
## Summary
- add a shared Strudel/Hydra audio transport that routes Strudel output into Hydra's `a.fft` without using the microphone
- update the UI with an audio-engine transport bar, REPL debug helpers, and an audio-reactive Hydra preset
- add a dev-only HUD to monitor `a.fft[0]` so it is obvious when Hydra is linked to Strudel audio

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926a51effc4832f9053185fc0135185)