### PR TITLE
fix: add missing mocks for StrudelRepl test

### DIFF
--- a/src/components/__tests__/StrudelRepl.test.tsx
+++ b/src/components/__tests__/StrudelRepl.test.tsx
@@ -40,10 +40,19 @@ vi.mock('@strudel/webaudio', () => ({
   samples: {}
 }));
 
+// Mock Strudel codemirror
+vi.mock('@strudel/codemirror', () => ({
+  sliderPlugin: vi.fn(() => ({})),
+  sliderWithID: vi.fn(),
+  updateSliderWidgets: vi.fn(),
+  widgetPlugin: vi.fn(() => ({}))
+}));
+
 // Mock Strudel engine
 vi.mock('../../services/strudelEngine', () => ({
   getReplInstance: vi.fn(),
-  hushAudio: vi.fn()
+  hushAudio: vi.fn(),
+  onWidgetUpdate: vi.fn()
 }));
 
 // Mock lucide-react icons


### PR DESCRIPTION
- Add mock for @strudel/codemirror module with sliderPlugin, sliderWithID, updateSliderWidgets, and widgetPlugin
- Add onWidgetUpdate to strudelEngine mock to support widget update callback used in useEffect hook

All 13 tests now passing